### PR TITLE
Remove Gitpod contributing section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,3 @@ To build the app for production, run:
 ```bash
 npm run build
 ```
-
-### Contributing
-
-You can use Gitpod in the cloud [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/pragadeeshnehru/TicTacToe/)


### PR DESCRIPTION
## Remove Gitpod Classic Integration from README

## Description
This PR removes the Gitpod "Ready-to-Code" badge and reference from the Contributing section in the README, as Gitpod Classic has been officially discontinued.

## Motivation and Context
Gitpod Classic was sunset and discontinued in April 2025. The service is no longer available, making the badge and integration link non-functional. Keeping outdated references in the README can confuse new contributors who may try to use a service that no longer exists.

**Key changes in Gitpod:**
- Gitpod Classic (the original Kubernetes-based SaaS) was discontinued in April 2025
- The button/badge linking to `gitpod.io/#https://github.com/...` no longer works
- Gitpod has rebranded and changed its product offering significantly

## Additional Notes
- This change removes outdated integration that is no longer functional
- Contributors can still use GitHub Codespaces, local development, or other cloud IDEs
- No `.gitpod.yml` file exists in the repository, so no additional cleanup needed
- If needed, we can suggest alternatives like GitHub Codespaces in a future PR

## Alternatives Considered
- **GitHub Codespaces**: A viable alternative for cloud-based development
- **Local Development**: Standard setup instructions remain in the README
- **DevContainers**: Can be added if cloud development environment is desired